### PR TITLE
apr example tests

### DIFF
--- a/test/SafEth.test.ts
+++ b/test/SafEth.test.ts
@@ -176,16 +176,19 @@ describe("SafEth", function () {
   const getApr = (
     time0: BigNumber,
     time1: BigNumber,
-    amount0: BigNumber,
-    amount1: BigNumber
+    price0: BigNumber,
+    price1: BigNumber
   ) => {
     const timeDiff = time1.sub(time0);
-    const amountDiff = amount1.sub(amount0);
+    const priceDiff = price1.sub(price0);
     // normalized in terms of wei for math because ethers BigNumber doesnt have decimals
-    const amountPerYear = ethers.utils.parseEther(
-      amountDiff.mul(31536000).div(timeDiff).toString()
+    const priceDiffPerYear = ethers.utils.parseEther(
+      priceDiff
+        .mul(60 * 60 * 24 * 365)
+        .div(timeDiff)
+        .toString()
     );
-    return ethers.utils.formatEther(amountPerYear.div(amount0));
+    return ethers.utils.formatEther(priceDiffPerYear.div(price0));
   };
 
   // find the first event that was at lease lengthOfTime ago


### PR DESCRIPTION
Calculates APR using `price` emitted from `Staked` events vs current price and the time difference:

- We find the first event at least X days old (7 days in this example). If none are older than 7 days it uses the oldest
- Calculate apr using difference between event price + time and current price + time

Since reth & wstEth update their prices daily its probably better to go back more than just 1 day in order to smooth out the apr calculation or it will be jumping quite a bit when update enter or fall out of the apr calculation period.