### PR TITLE
3.3 Return first enabled derivative on firstUnderWeightDerivativeIndex

### DIFF
--- a/contracts/SafEth/SafEth.sol
+++ b/contracts/SafEth/SafEth.sol
@@ -441,7 +441,7 @@ contract SafEth is
         if (safEthTotalSupply == 0 || underlyingValue == 0) return 1e18;
         return (underlyingValue) / safEthTotalSupply;
     }
-    
+
     /**
      * @notice - find derivative that is underweight relative to target weights
      * @return - a derivative index that is underweight relative to target weights


### PR DESCRIPTION
This PR fixes firstUnderweightDerivativeIndex defaulting to zero if there are no underweight derivatives.

This is merging into https://github.com/asymmetryfinance/smart-contracts/pull/432 because it uses the new enabledDerivatives array